### PR TITLE
[zig]: fix use of dead stack variables

### DIFF
--- a/zig/src/gameboy.zig
+++ b/zig/src/gameboy.zig
@@ -14,24 +14,16 @@ pub const GameBoy = struct {
     apu: APU,
     buttons: Buttons,
     clock: Clock,
+    cart: Cart,
 
-    pub fn new(args: Args) !GameBoy {
-        var cart = try Cart.new(args.rom);
-        var ram = try RAM.new(&cart);
-        var cpu = try CPU.new(&ram, args.debug_cpu);
-        var gpu = try GPU.new(&cpu, cart.name, args.headless, args.debug_gpu);
-        var apu = try APU.new(args.silent, args.debug_apu);
-        var buttons = try Buttons.new(&cpu, &ram, args.headless);
-        var clock = try Clock.new(&buttons, args.profile, args.turbo);
-
-        return GameBoy{
-            .ram = ram,
-            .cpu = cpu,
-            .gpu = gpu,
-            .apu = apu,
-            .buttons = buttons,
-            .clock = clock,
-        };
+    pub fn init(gb: *GameBoy, args: Args) !void {
+        gb.cart = try Cart.new(args.rom);
+        gb.ram = try RAM.new(&gb.cart);
+        gb.cpu = try CPU.new(&gb.ram, args.debug_cpu);
+        gb.gpu = try GPU.new(&gb.cpu, gb.cart.name, args.headless, args.debug_gpu);
+        gb.apu = try APU.new(args.silent, args.debug_apu);
+        gb.buttons = try Buttons.new(&gb.cpu, &gb.ram, args.headless);
+        gb.clock = try Clock.new(&gb.buttons, args.profile, args.turbo);
     }
 
     pub fn run(self: *GameBoy) !void {

--- a/zig/src/main.zig
+++ b/zig/src/main.zig
@@ -21,7 +21,8 @@ pub fn main() anyerror!void {
     defer SDL.quit();
 
     // FIXME: catch errors, return appropriate exit codes
-    var gameboy = try GameBoy.new(args);
+    var gameboy: GameBoy = undefined;
+    try gameboy.init(args);
     gameboy.run() catch |err| {
         switch (err) {
             errors.ControlledExit.UnitTestPassed => {


### PR DESCRIPTION
Howdy! Thanks for making this nifty project. I wanted to use it to take a data point to find out machine code quality of Zig's old compiler vs the new compiler. So I tried compiling it without `-fstage1` but ran into https://github.com/ziglang/zig/issues/13340. I worked around that with a small diff to `Sprite.Flags` inside this PR which perhaps you will find acceptable (alternately you could just wait until that issue is fixed and then that part of this PR could be dropped).

Next, I hit a segfault, and so I ran the binary in Valgrind, and there were a lot of errors like this:

```
==938067== Invalid read of size 32
==938067==    at 0x2F31F9: memcpy (in /home/andy/Downloads/rosettaboy/zig/rosettaboy-2)
==938067==    by 0x2526D2: ram.RAM.get (ram.zig:207)
==938067==    by 0x258DDD: cpu.CPU.tick_interrupts (cpu.zig:333)
==938067==    by 0x25894E: cpu.CPU.tick (cpu.zig:227)
==938067==    by 0x25D9C3: gameboy.GameBoy.tick (gameboy.zig:44)
==938067==    by 0x25DAD4: gameboy.GameBoy.run (gameboy.zig:39)
==938067==    by 0x25DCFE: main.main (main.zig:25)
==938067==    by 0x25E33F: callMain (start.zig:578)
==938067==    by 0x25E33F: initEventLoopAndCallMain (start.zig:512)
==938067==    by 0x25E33F: callMainWithArgs (start.zig:462)
==938067==    by 0x25E33F: main (start.zig:477)
==938067==  Address 0x1ffef9c0a7 is on thread 1's stack
==938067==  131945 bytes below stack pointer
```

So that lead to reworking `GameBoy.new` into `GameBoy.init` to avoid keeping pointers to dead stack variables. It's too bad that code like what you had originally doesn't work; that pattern is the motivation behind this proposal: https://github.com/ziglang/zig/issues/2765

Who knows, maybe we'll get that pattern working someday. But as it stands, that code is not legal because dead stack variables are being accessed. Related: https://github.com/ziglang/zig/issues/3180 - this will make debugging such issues more deterministic.

After fixing that issue, Valgrind got much quieter, only showing two things left:

```
==938494== Invalid read of size 8
==938494==    at 0x25903F: sdl.Renderer.setColor (sdl.zig:634)
==938494==    by 0x25BE96: gpu.GPU.tick (gpu.zig:160)
==938494==    by 0x25D9EC: gameboy.GameBoy.tick (gameboy.zig:37)
==938494==    by 0x25DAC4: gameboy.GameBoy.run (gameboy.zig:31)
==938494==    by 0x25DD35: main.main (main.zig:26)
==938494==    by 0x25E36F: callMain (start.zig:578)
==938494==    by 0x25E36F: initEventLoopAndCallMain (start.zig:512)
==938494==    by 0x25E36F: callMainWithArgs (start.zig:462)
==938494==    by 0x25E36F: main (start.zig:477)
==938494==  Address 0x1ffefdc2a8 is on thread 1's stack
==938494==  66712 bytes below stack pointer
==938494== 
==938494== Invalid read of size 8
==938494==    at 0x2590BC: sdl.Renderer.clear (sdl.zig:558)
==938494==    by 0x25BF01: gpu.GPU.tick (gpu.zig:161)
==938494==    by 0x25D9EC: gameboy.GameBoy.tick (gameboy.zig:37)
==938494==    by 0x25DAC4: gameboy.GameBoy.run (gameboy.zig:31)
==938494==    by 0x25DD35: main.main (main.zig:26)
==938494==    by 0x25E36F: callMain (start.zig:578)
==938494==    by 0x25E36F: initEventLoopAndCallMain (start.zig:512)
==938494==    by 0x25E36F: callMainWithArgs (start.zig:462)
==938494==    by 0x25E36F: main (start.zig:477)
==938494==  Address 0x1ffefdc2a8 is on thread 1's stack
==938494==  66712 bytes below stack pointer
```

So I peeked into the SDL sdk.zig file and noticed that `SDL.Renderer` is a struct that wraps a pointer, so no need to take a double pointer. This prevents hanging onto a pointer to the wrapping struct when what is really desired is a copy of the pointer.

After fixing that, Valgrind went silent and the binary started working. Then I was able to collect the data point that I wanted:

```
[nix-shell:~/Downloads/rosettaboy/zig]$ hyperfine "./rosettaboy-1 --profile 600 --silent --headless --turbo opus5.gb" "./rosettaboy-2 --profile 600 --silent --headless --turbo opus5.gb"
Benchmark 1: ./rosettaboy-1 --profile 600 --silent --headless --turbo opus5.gb
  Time (mean ± σ):     321.9 ms ±   5.0 ms    [User: 319.1 ms, System: 1.3 ms]
  Range (min … max):   316.9 ms … 334.1 ms    10 runs
 
Benchmark 2: ./rosettaboy-2 --profile 600 --silent --headless --turbo opus5.gb
  Time (mean ± σ):     298.1 ms ±   1.0 ms    [User: 295.2 ms, System: 2.0 ms]
  Range (min … max):   296.5 ms … 300.0 ms    10 runs
 
Summary
  './rosettaboy-2 --profile 600 --silent --headless --turbo opus5.gb' ran
    1.08 ± 0.02 times faster than './rosettaboy-1 --profile 600 --silent --headless --turbo opus5.gb'
```

Sweet! Looks like the new compiler generates better LLVM IR than the old one :slightly_smiling_face: 