### PR TITLE
[nim] modern compile flags

### DIFF
--- a/nim/run_speed.sh
+++ b/nim/run_speed.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -eu
 cd $(dirname $0)
-nimble --accept build -d:release --opt:speed
+nimble --accept build -d:danger --opt:speed -d:lto --mm:arc --panics:on
 exec ./rosettaboy $*


### PR DESCRIPTION
Running on my machine using daa54a6de67c6c7f21125372afb52c311ddd8954:
`Emulated 600 frames in  0.53s (1136fps)`

WIth this change:
`Emulated 600 frames in  0.38s (1568fps)`

1. [`--mm:arc`](https://nim-lang.org/docs/mm.html)
1. "The benefit of [`--panics:on`](https://github.com/nim-lang/Nim/blob/devel/doc/manual.md?plain=1#L134) is that it produces smaller binary code and the compiler has more freedom to optimize the code."
