### PR TITLE
[all] implement the set(addr, val) half of --debug-ram

### DIFF
--- a/cpp/src/args.cpp
+++ b/cpp/src/args.cpp
@@ -10,6 +10,7 @@ Args::Args(int argc, char *argv[]) {
     args::Flag debug_cpu(parser, "debug-cpu", "Debug CPU", {'c', "debug-cpu"});
     args::Flag debug_gpu(parser, "debug-gpu", "Debug GPU", {'g', "debug-gpu"});
     args::Flag debug_apu(parser, "debug-apu", "Debug APU", {'a', "debug-apu"});
+    args::Flag debug_ram(parser, "debug-ram", "Debug RAM", {'a', "debug-ram"});
     args::ValueFlag<int> frames(parser, "frames", "Exit after N frames", {'f', "frames"});
     args::ValueFlag<int> profile(parser, "profile", "Exit after N seconds", {'p', "profile"});
     args::Flag turbo(parser, "turbo", "No sleep between frames", {'t', "turbo"});
@@ -37,6 +38,7 @@ Args::Args(int argc, char *argv[]) {
     this->debug_cpu = debug_cpu;
     this->debug_apu = debug_apu;
     this->debug_gpu = debug_gpu;
+    this->debug_ram = debug_ram;
     this->frames = frames ? args::get(frames) : 0;
     this->profile = profile ? args::get(profile) : 0;
     this->turbo = turbo;

--- a/cpp/src/args.h
+++ b/cpp/src/args.h
@@ -12,6 +12,7 @@ public:
     bool debug_cpu;
     bool debug_gpu;
     bool debug_apu;
+    bool debug_ram;
     int frames;
     int profile;
     bool turbo;

--- a/cpp/src/gameboy.cpp
+++ b/cpp/src/gameboy.cpp
@@ -2,7 +2,7 @@
 
 GameBoy::GameBoy(Args *args) {
     this->cart = new Cart(args->rom);
-    this->ram = new RAM(this->cart);
+    this->ram = new RAM(this->cart, args->debug_ram);
     this->cpu = new CPU(this->ram, args->debug_cpu);
     this->gpu = new GPU(this->cpu, cart->name, args->headless, args->debug_gpu);
     this->buttons = new Buttons(this->cpu, args->headless);

--- a/cpp/src/ram.cpp
+++ b/cpp/src/ram.cpp
@@ -31,7 +31,8 @@ u8 BOOT[0x100] = {
     0xC3, 0xFD, 0x00, // JP 0x00FD
 };
 
-RAM::RAM(Cart *cart) {
+RAM::RAM(Cart *cart, bool debug) {
+    this->debug = debug;
     this->cart = cart;
     this->boot = BOOT;
 

--- a/cpp/src/ram.h
+++ b/cpp/src/ram.h
@@ -23,7 +23,7 @@ private:
     bool debug = false;
 
 public:
-    RAM(Cart *cart);
+    RAM(Cart *cart, bool debug);
     u8 data[0xFFFF + 1];
     void dump();
 
@@ -103,6 +103,9 @@ inline u8 RAM::get(u16 addr) {
 }
 
 inline void RAM::set(u16 addr, u8 val) {
+    if(this->debug) {
+        printf("ram[%04X] <- %02X\n", addr, val);
+    }
     switch(addr) {
         case 0x0000 ... 0x1FFF: {
             bool newval = (val != 0);

--- a/go/src/ram.go
+++ b/go/src/ram.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"io/ioutil"
 )
 
@@ -217,6 +218,9 @@ func (ram *RAM) get(addr uint16) uint8 {
 }
 
 func (ram *RAM) set(addr uint16, val uint8) {
+	if ram.debug {
+		fmt.Printf("ram[%04X] <- %02X\n", addr, val)
+	}
 	switch {
 	case addr < 0x2000:
 		ram.ram_enable = val != 0

--- a/nim/src/gameboy.nim
+++ b/nim/src/gameboy.nim
@@ -18,7 +18,7 @@ type
 
 proc create*(args: args.Args): GameBoy =
     let cart = cart.create(args.rom)
-    let ram = ram.create(cart)
+    let ram = ram.create(cart, args.debugRam)
     let cpu = cpu.create(ram, args.debugCpu);
     let gpu = gpu.create(cpu, ram, cart.name, args.headless, args.debugGpu)
     let apu = apu.create(args.silent, args.debugApu)

--- a/nim/src/ram.nim
+++ b/nim/src/ram.nim
@@ -1,3 +1,4 @@
+import std/strformat
 import std/streams
 import std/os
 import std/bitops
@@ -50,6 +51,7 @@ const RAM_BANK_SIZE: uint16 = 0x2000
 
 type
     RAM* = ref object
+        debug: bool
         cart: cart.Cart
         ramEnable: bool
         ramBankMode: bool
@@ -60,7 +62,7 @@ type
         boot: array[0x100, uint8]
         data*: array[0xFFFF+1, uint8]
 
-proc create*(cart: Cart): RAM =
+proc create*(cart: Cart, debug: bool): RAM =
     var boot: array[0x100, uint8]
     try:
         if not fileExists("boot.gb"):
@@ -80,6 +82,7 @@ proc create*(cart: Cart): RAM =
             boot[i] = BOOT[i].uint8
 
     return RAM(
+      debug: debug,
       cart: cart,
       ramEnable: true,
       romBank_low: 1,
@@ -158,6 +161,9 @@ func get*(self: RAM, address: uint16): uint8 =
             return self.data[address.int];
 
 proc set*(self: var RAM, address: uint16, val: uint8) =
+    if self.debug:
+        echo fmt"ram[{address:04X}] <- {val:02X}"
+
     case address:
         of 0x0000..0x1FFF:
             self.ramEnable = val != 0;

--- a/php/src/ram.php
+++ b/php/src/ram.php
@@ -125,6 +125,9 @@ class RAM
 
     public function set(int $addr, int $val): void
     {
+        if ($this->debug) {
+            printf("ram[%04X] <- %02X\n", $addr, $val);
+        }
         if ($addr < 0x2000) {
             $newval = ($val != 0);
             // if($this->ram_enable != newval) printf("ram_enable set to %d\n", newval);

--- a/py/src/ram.py
+++ b/py/src/ram.py
@@ -212,6 +212,8 @@ class RAM:
         return self.data[addr]
 
     def __setitem__(self, addr: u16, val: u8) -> None:
+        if self.debug:
+            print(f"ram[{addr:04X}] <- {val:02X}")
         if addr < 0x2000:
             self.ram_enable = val != 0
         elif addr < 0x4000:

--- a/rs/src/gameboy.rs
+++ b/rs/src/gameboy.rs
@@ -26,7 +26,7 @@ impl<'a> GameBoy<'a> {
 
         let cart = cart::Cart::new(args.rom.as_str())?;
         let cart_name = cart.name.clone();
-        let ram = ram::RAM::new(cart)?;
+        let ram = ram::RAM::new(cart, args.debug_ram)?;
         let cpu = cpu::CPU::new(args.debug_cpu);
         let gpu = gpu::GPU::new(&sdl, cart_name, args.headless, args.debug_gpu)?;
         let apu = apu::APU::new(&sdl, args.silent, args.debug_apu)?;

--- a/rs/src/ram.rs
+++ b/rs/src/ram.rs
@@ -52,6 +52,7 @@ const ROM_BANK_SIZE: u16 = 0x4000;
 const RAM_BANK_SIZE: u16 = 0x2000;
 
 pub struct RAM {
+    debug: bool,
     cart: cart::Cart,
     ram_enable: bool,
     ram_bank_mode: bool,
@@ -64,7 +65,7 @@ pub struct RAM {
 }
 
 impl RAM {
-    pub fn new(cart: cart::Cart) -> Result<RAM> {
+    pub fn new(cart: cart::Cart, debug: bool) -> Result<RAM> {
         let boot = match ::std::fs::File::open("boot.gb") {
             Ok(mut fp) => {
                 tracing::debug!("Loading boot code from boot.gb");
@@ -80,6 +81,7 @@ impl RAM {
         };
 
         Ok(RAM {
+            debug,
             cart,
             ram_enable: true, // false,
             ram_bank_mode: false,
@@ -166,6 +168,9 @@ impl RAM {
     #[inline(always)]
     pub fn set<T: Into<u16>>(&mut self, addr: T, val: u8) {
         let addr = addr.into();
+        if self.debug {
+            println!("ram[{:04X}] <- {:02X}", addr, val);
+        }
         match addr {
             0x0000..=0x1FFF => {
                 self.ram_enable = val != 0;

--- a/zig/src/gameboy.zig
+++ b/zig/src/gameboy.zig
@@ -18,7 +18,7 @@ pub const GameBoy = struct {
 
     pub fn init(gb: *GameBoy, args: Args) !void {
         gb.cart = try Cart.new(args.rom);
-        gb.ram = try RAM.new(&gb.cart);
+        gb.ram = try RAM.new(&gb.cart, args.debug_ram);
         gb.cpu = try CPU.new(&gb.ram, args.debug_cpu);
         gb.gpu = try GPU.new(&gb.cpu, gb.cart.name, args.headless, args.debug_gpu);
         gb.apu = try APU.new(args.silent, args.debug_apu);

--- a/zig/src/ram.zig
+++ b/zig/src/ram.zig
@@ -113,6 +113,7 @@ fn panic(s: []const u8) void {
 }
 
 pub const RAM = struct {
+    debug: bool,
     cart: *Cart,
     ram_enable: bool,
     ram_bank_mode: bool,
@@ -123,8 +124,9 @@ pub const RAM = struct {
     boot: [0x100]u8,
     data: [0xFFFF + 1]u8,
 
-    pub fn new(cart: *Cart) !RAM {
+    pub fn new(cart: *Cart, debug: bool) !RAM {
         return RAM{
+            .debug = debug,
             .cart = cart,
             .ram_enable = true, // false,
             .ram_bank_mode = false,
@@ -207,6 +209,9 @@ pub const RAM = struct {
         return self.data[addr];
     }
     pub fn set(self: *RAM, addr: u16, val: u8) void {
+        if (self.debug) {
+            std.debug.print("ram[{X:0>4}] <- {X:0>2}\n", .{ addr, val });
+        }
         switch (addr) {
             0x0000...0x1FFF => {
                 self.ram_enable = val != 0;


### PR DESCRIPTION
Stack created with [Sapling]
* __->__ #53

[all] implement the set(addr, val) half of --debug-ram

This was useful in tracing down a bug where OAM data was being set off-by-one

