### PR TITLE
[all] check that unit test output contains "passed"

### DIFF
--- a/utils/blargg.py
+++ b/utils/blargg.py
@@ -56,7 +56,7 @@ def test(cwd, rom):
         errors="replace",
     )
     rom_name = rom.replace(f"{TEST_DIR}/", "")
-    if p.returncode == 0:
+    if p.returncode == 0 and "Unit test passed" in p.stdout:
         print(f"{cwd} {rom_name} = {GREEN}Passed{END}")
     elif p.returncode == 2:
         print(f"{cwd} {rom_name} = {RED}Failed{END}")

--- a/zig/src/main.zig
+++ b/zig/src/main.zig
@@ -31,11 +31,11 @@ pub fn main() anyerror!void {
     gameboy.run() catch |err| {
         switch (err) {
             errors.ControlledExit.UnitTestPassed => {
-                std.debug.print("Unit Test Passed\n", .{});
+                std.debug.print("Unit test passed\n", .{});
                 std.os.exit(0);
             },
             errors.ControlledExit.UnitTestFailed => {
-                std.debug.print("Unit Test Failed\n", .{});
+                std.debug.print("Unit test failed\n", .{});
                 std.os.exit(2);
             },
             errors.ControlledExit.Timeout => {


### PR DESCRIPTION
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/shish/rosettaboy/pull/56).
* __->__ #56

[all] check that unit test output contains "passed"

Right now we only check the exit code, and `--frames 2000` (used to to avoid getting stuck forever in an infinite loop) exits with 0

