### PR TITLE
Load op args from RAM in the same order

### DIFF
--- a/cpp/src/cpu.cpp
+++ b/cpp/src/cpu.cpp
@@ -187,13 +187,14 @@ void CPU::tick_main(u8 op) {
     arg.as_u16 = 0xCA75;
     u8 nargs = OP_ARG_BYTES[OP_ARG_TYPES[op]];
     if(nargs == 1) {
-        arg.as_u8 = this->ram->get(this->PC++);
+        arg.as_u8 = this->ram->get(this->PC);
     }
     if(nargs == 2) {
-        u16 low = this->ram->get(this->PC++);
-        u16 high = this->ram->get(this->PC++);
+        u16 low = this->ram->get(this->PC);
+        u16 high = this->ram->get(this->PC + 1);
         arg.as_u16 = high << 8 | low;
     }
+    this->PC += nargs;
 
     // Execute
     u8 val = 0, carry = 0;

--- a/go/src/cpu.go
+++ b/go/src/cpu.go
@@ -228,7 +228,7 @@ func (cpu *CPU) dump_regs() {
 		case 1:
 			op_str = fmt.Sprintf(OP_NAMES[op], cpu.ram.get(cpu.PC+1))
 		case 2:
-			op_str = fmt.Sprintf(OP_NAMES[op], uint16(cpu.ram.get(cpu.PC+2))<<8|uint16(cpu.ram.get(cpu.PC+1)))
+			op_str = fmt.Sprintf(OP_NAMES[op], uint16(cpu.ram.get(cpu.PC+1))|uint16(cpu.ram.get(cpu.PC+2))<<8)
 		case 3:
 			op_str = fmt.Sprintf(OP_NAMES[op], int8(cpu.ram.get(cpu.PC+1)))
 		}
@@ -363,15 +363,13 @@ func (cpu *CPU) tick_main(op uint8) error {
 	if nargs == 1 {
 		arg.as_u8 = cpu.ram.get(cpu.PC)
 		arg.as_i8 = int8(arg.as_u8)
-		cpu.PC++
 	}
 	if nargs == 2 {
 		var low = cpu.ram.get(cpu.PC)
-		cpu.PC++
-		var high = cpu.ram.get(cpu.PC)
-		cpu.PC++
+		var high = cpu.ram.get(cpu.PC + 1)
 		arg.as_u16 = uint16(high)<<8 | uint16(low)
 	}
+	cpu.PC += uint16(nargs)
 
 	// Execute
 	var val uint8 = 0

--- a/nim/src/cpu.nim
+++ b/nim/src/cpu.nim
@@ -368,14 +368,13 @@ proc tickMain(self: var CPU, op: uint8) =
     var nargs = OP_ARG_BYTES[OP_ARG_TYPES[op]];
     if nargs == 1:
         arg.asU8 = self.ram.get(self.pc)
-        self.pc+=1
 
     if nargs == 2:
         var arglow = self.ram.get(self.pc).uint16
-        self.pc+=1
-        var arghigh = self.ram.get(self.pc).uint16
-        self.pc+=1
+        var arghigh = self.ram.get(self.pc+1).uint16
         arg.asU16 = bitor(arghigh shl 8, arglow)
+
+    self.pc += nargs.uint16
 
 
     # Execute

--- a/php/src/cpu.php
+++ b/php/src/cpu.php
@@ -430,15 +430,13 @@ class CPU
         if ($nargs == 1) {
             $arg->as_u8 = $this->ram->get($this->PC);
             $arg->as_i8 = int8($arg->as_u8);
-            $this->PC++;
         }
         if ($nargs == 2) {
             $low = $this->ram->get($this->PC);
-            $this->PC++;
-            $high = $this->ram->get($this->PC);
-            $this->PC++;
-            $arg->as_u16 = uint16($high) << 8 | uint16($low);
+            $high = $this->ram->get($this->PC+1);
+            $arg->as_u16 = uint16($low) | uint16($high) << 8;
         }
+        $this->PC += $nargs;
 
         // Execute
         switch ($op) {

--- a/py/src/buttons.py
+++ b/py/src/buttons.py
@@ -66,7 +66,7 @@ class Buttons:
                 JOYP |= Joypad.START
             if self.select:
                 JOYP |= Joypad.SELECT
-        
+
         self.cpu.ram[Mem.JOYP] = ~JOYP & 0xFF
 
     def handle_inputs(self) -> bool:

--- a/rs/src/cpu.rs
+++ b/rs/src/cpu.rs
@@ -64,7 +64,7 @@ pub const OP_TYPES: [u8; 0x100] = [
 ];
 
 // no arg, u8, u16, i8
-pub const OP_LENS: [u16; 4] = [0, 1, 2, 1];
+pub const OP_ARG_BYTES: [u16; 4] = [0, 1, 2, 1];
 
 #[rustfmt::skip]
 pub const OP_NAMES: [&str; 0x100] = [
@@ -454,7 +454,7 @@ impl CPU {
             },
             2 => OpArg {
                 u8: 0,
-                u16: (ram.get(addr + 1) as u16) << 8 | (ram.get(addr) as u16),
+                u16: (ram.get(addr) as u16) | (ram.get(addr + 1) as u16) << 8,
                 i8: 0,
             },
             3 => OpArg {
@@ -469,7 +469,7 @@ impl CPU {
     fn tick_main(&mut self, ram: &mut ram::RAM, op: u8) -> Result<()> {
         let arg = {
             let arg_type = OP_TYPES[op as usize];
-            let arg_len = OP_LENS[arg_type as usize];
+            let arg_len = OP_ARG_BYTES[arg_type as usize];
             let arg = self.load_op(ram, self.pc, arg_type);
             self.pc += arg_len;
             arg

--- a/zig/src/cpu.zig
+++ b/zig/src/cpu.zig
@@ -66,7 +66,7 @@ pub const OP_TYPES = [_]u2{
 };
 
 // no arg, u8, u16, i8
-pub const OP_LENS = [_]u2{ 0, 1, 2, 1 };
+pub const OP_ARG_BYTES = [_]u2{ 0, 1, 2, 1 };
 
 pub const OP_NAMES = [_][]const u8{
     "NOP",          "LD BC,$u16", "LD [BC],A",   "INC BC",    "INC B",        "DEC B",     "LD B,$u8",    "RCLA",
@@ -402,7 +402,7 @@ pub const CPU = struct {
                 .u8 = self.ram.get(addr),
             },
             2 => OpArg{
-                .u16 = @intCast(u16, self.ram.get(addr + 1)) << 8 | (self.ram.get(addr)),
+                .u16 = @intCast(u16, self.ram.get(addr)) | @intCast(u16, self.ram.get(addr + 1)) << 8,
             },
             3 => OpArg{
                 .i8 = @bitCast(i8, self.ram.get(addr)),
@@ -412,7 +412,7 @@ pub const CPU = struct {
 
     fn tick_main(self: *CPU, op: u8) !void {
         var arg_type = OP_TYPES[op];
-        var arg_len = OP_LENS[arg_type];
+        var arg_len = OP_ARG_BYTES[arg_type];
         var arg = self.load_op(self.pc, arg_type);
         self.pc += arg_len;
 


### PR DESCRIPTION
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/shish/rosettaboy/pull/58).
* __->__ #58

Load op args from RAM in the same order

