### PR TITLE
[cpp/nix] add derivation to build cpp

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -9,6 +9,9 @@ on:
       build-pkgs:
         required: false
         type: string
+      build-nix:
+        required: false
+        type: boolean
       format-pkgs:
         required: false
         type: string
@@ -120,6 +123,12 @@ jobs:
       uses: cachix/install-nix-action@v15
       with:
         nix_path: nixpkgs=channel:nixos-22.11
+    - name: Build
+      if: inputs.build-nix
+      run: nix build --file ${{ inputs.workdir }}/default.nix
+    - name: Run via Nix
+      if: inputs.build-nix
+      run: nix run --file ${{ inputs.workdir }}/default.nix default -- --help
     - name: Run
       shell: bash
       working-directory: ${{ inputs.workdir }}

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -24,3 +24,4 @@ jobs:
       cache-paths: |
         cpp/build
       cache-key: build
+      build-nix: true

--- a/cpp/.gitignore
+++ b/cpp/.gitignore
@@ -10,3 +10,4 @@ CMakeFiles
 Makefile
 cmake_install.cmake
 rosettaboy-cpp
+/result*

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -8,9 +8,13 @@ option(ENABLE_LTO "enable LTO" OFF)
 include(CheckIPOSupported)
 check_ipo_supported(RESULT supported OUTPUT error)
 
+include(GNUInstallDirs)
+
 include_directories(/usr/local/include/)
 
 add_executable(rosettaboy-cpp src/main.cpp src/args.cpp src/cpu.cpp src/cart.cpp src/gameboy.cpp src/gpu.cpp src/consts.h src/cart.h src/cpu.h src/gpu.h src/args.h src/apu.cpp src/apu.h src/ram.cpp src/ram.h src/buttons.cpp src/buttons.h src/clock.cpp src/clock.h)
+install(TARGETS rosettaboy-cpp
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 if( ENABLE_LTO AND supported )
     message(STATUS "IPO / LTO enabled")

--- a/cpp/default.nix
+++ b/cpp/default.nix
@@ -1,0 +1,25 @@
+{ pkgs ? import <nixpkgs> { }
+}:
+
+let
+  makeDerivation = { ltoSupport, debugSupport }: pkgs.callPackage ./derivation.nix {
+    inherit ltoSupport debugSupport;
+  };
+in
+
+{
+  default = makeDerivation {
+    ltoSupport = false;
+    debugSupport = false;
+  };
+
+  debug = makeDerivation {
+    ltoSupport = false;
+    debugSupport = true;
+  };
+
+  lto = makeDerivation {
+    ltoSupport = true;
+    debugSupport = true;
+  };
+}

--- a/cpp/derivation.nix
+++ b/cpp/derivation.nix
@@ -1,0 +1,31 @@
+{ lib
+, stdenv
+, cmake
+, SDL2
+, autoPatchelfHook
+, pkg-config
+, ltoSupport ? false
+, debugSupport ? false
+}:
+
+stdenv.mkDerivation {
+  name = "rosettaboy-cpp";
+
+  src = ./.;
+
+  enableParallelBuilding = true;
+
+  buildInputs = [ SDL2 ];
+  nativeBuildInputs = [ autoPatchelfHook cmake pkg-config ];
+
+  cmakeFlags = [ ]
+    ++ lib.optional debugSupport "-DCMAKE_BUILD_TYPE=Debug"
+    ++ lib.optional (!debugSupport) "-DCMAKE_BUILD_TYPE=Release"
+    ++ lib.optional ltoSupport "-DENABLE_LTO=On"
+  ;
+  
+  meta = with lib; {
+    description = "rosettaboy-cpp";
+    mainProgram = "rosettaboy-cpp";
+  };
+}

--- a/cpp/shell.nix
+++ b/cpp/shell.nix
@@ -1,9 +1,14 @@
-{ pkgs ? import <nixpkgs> {} } : pkgs.mkShell {
-	buildInputs = with pkgs; [
-		cmake
-		gnumake
-		SDL2
-				
-		clang-tools # Massive, and only used for format.sh. But I think it may share some dependencies with Nim, Zig (11/generic, I think), Rust. Painful because the other requirements are so small.
-	];
+{ pkgs ? import <nixpkgs> { }
+}:
+
+let
+  packages = pkgs.callPackage ./default.nix { inherit pkgs; };
+in
+
+pkgs.mkShell {
+  inputsFrom = [ packages.debug ];
+  nativeBuildInputs = with pkgs; [
+    clang-tools # Massive, and only used for format.sh. But I think it may share some dependencies with Nim, Zig (11/generic, I think), Rust. Painful because the other requirements are so small.
+    nixpkgs-fmt
+  ];
 }


### PR DESCRIPTION
See: https://github.com/shish/rosettaboy/issues/111#issuecomment-1407751519

To switch to flakes, if using flake-utils, we should be able to do something like:

```nix
rec {
  packages = rec {
    cpp = pkgs.callPackage ./cpp/default.nix { inherit pkgs; };
  };

  devShells = rec {
    cpp = packages.cpp.default;
    default = pkgs.mkShell {
      inputsFrom = [ cpp ];
    };
  };
}
```

to `flake.nix`, or you can move the logic in `default.nix`/`shell.nix` into the `flake.nix` and drop them (or shim them with flake-compat).

Caveat: I'm on nixos so I don't know if this will work on mac, although I don't see why it wouldn't.