### PR TITLE
[cpp] use {fmt} library

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -20,7 +20,7 @@ jobs:
     with:
       workdir: cpp
       format-pkgs: clang-format-14
-      build-pkgs: gcc cmake libsdl2-dev
+      build-pkgs: gcc cmake libsdl2-dev libfmt-dev
       cache-paths: |
         cpp/build
       cache-key: build

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -19,6 +19,7 @@ if( ENABLE_LTO AND supported )
     set_property(TARGET rosettaboy-cpp PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
 endif()
 
+find_package(fmt REQUIRED)
 find_package(SDL2 REQUIRED)
 include_directories(${SDL2_INCLUDE_DIRS})
-target_link_libraries(rosettaboy-cpp ${SDL2_LIBRARIES})
+target_link_libraries(rosettaboy-cpp ${SDL2_LIBRARIES} fmt::fmt-header-only)

--- a/cpp/shell.nix
+++ b/cpp/shell.nix
@@ -3,6 +3,7 @@
 		cmake
 		gnumake
 		SDL2
+		fmt_8
 				
 		clang-tools # Massive, and only used for format.sh. But I think it may share some dependencies with Nim, Zig (11/generic, I think), Rust. Painful because the other requirements are so small.
 	];

--- a/cpp/src/cart.cpp
+++ b/cpp/src/cart.cpp
@@ -1,5 +1,6 @@
 #include <cstring>
 #include <fcntl.h>
+#include <fmt/core.h>
 #include <iostream>
 #include <sys/mman.h>
 #include <sys/stat.h>
@@ -83,17 +84,20 @@ Cart::Cart(std::string filename) {
     }
 
     if(debug) {
-        printf("name         : %s\n", name);
-        printf("is_gbc       : %d\n", is_gbc);
-        printf("is_sgb       : %d\n", is_sgb);
-        printf("licensee     : %d\n", licensee);
-        printf("old_licensee : %d\n", old_licensee);
-        printf("destination  : %d\n", destination);
-        printf("cart_type    : %d\n", cart_type);
-        printf("rom_size     : %u\n", rom_size);
-        printf("ram_size     : %u\n", ram_size);
-        printf("rom_version  : %d\n", rom_version);
-        printf("ccheck       : %d\n", complement_check);
-        printf("checksum     : %d\n", checksum);
+        fmt::print(
+            "name         : {name}\n"
+            "is_gbc       : {is_gbc}\n"
+            "is_sgb       : {is_sgb}\n"
+            "licensee     : {licensee}\n"
+            "old_licensee : {old_licensee}\n"
+            "destination  : {destination}\n"
+            "cart_type    : {cart_type}\n"
+            "rom_size     : {rom_size}\n"
+            "ram_size     : {ram_size}\n"
+            "rom_version  : {rom_version}\n"
+            "ccheck       : {complement_check}\n"
+            "checksum     : {checksum}\n",
+            name, is_gbc, is_sgb, licensee, old_licensee, destination, cart_type, rom_size, ram_size, rom_version,
+            complement_check, checksum);
     }
 }

--- a/cpp/src/gpu.cpp
+++ b/cpp/src/gpu.cpp
@@ -1,4 +1,5 @@
 #include <SDL2/SDL.h>
+#include <fmt/core.h>
 
 #include "consts.h"
 #include "gpu.h"
@@ -30,7 +31,7 @@ GPU::GPU(CPU *cpu, char *title, bool headless, bool debug) {
     if(!headless) {
         SDL_InitSubSystem(SDL_INIT_VIDEO);
         char title_buf[64];
-        snprintf(title_buf, 64, "RosettaBoy - %s", title);
+        fmt::format_to_n(title_buf, 64, "RosettaBoy - {}", title);
         this->hw_window = SDL_CreateWindow(
             title_buf,                                      // window title
             SDL_WINDOWPOS_UNDEFINED,                        // initial x position

--- a/cpp/src/main.cpp
+++ b/cpp/src/main.cpp
@@ -26,6 +26,6 @@ int main(int argc, char *argv[]) {
         return 4;
     }
 
-    printf("\n");
+    std::cout << std::endl;
     return 0;
 }

--- a/cpp/src/ram.h
+++ b/cpp/src/ram.h
@@ -1,6 +1,7 @@
 #ifndef ROSETTABOY_RAM_H
 #define ROSETTABOY_RAM_H
 
+#include <fmt/core.h>
 #include <stdexcept>
 
 #include "cart.h"
@@ -62,7 +63,7 @@ inline u8 RAM::get(u16 addr) {
         case 0xA000 ... 0xBFFF: {
             // 8KB Switchable RAM bank
             if(!this->ram_enable) {
-                printf("ERR: Reading from external ram while disabled: %04X\n", addr);
+                fmt::print("ERR: Reading from external ram while disabled: {:#06X}\n", addr);
                 return 0;
             }
             int bank = this->ram_bank * RAM_BANK_SIZE;
@@ -103,14 +104,14 @@ inline u8 RAM::get(u16 addr) {
     }
 
     if(this->debug) {
-        printf("ram[%04X] -> %02X\n", addr, val);
+        fmt::print("ram[{addr:#06X}] -> {val:#X}\n", addr, val);
     }
     return val;
 }
 
 inline void RAM::set(u16 addr, u8 val) {
     if(this->debug) {
-        printf("ram[%04X] <- %02X\n", addr, val);
+        fmt::print("ram[{addr:#06X}] <- {val:#X}\n", addr, val);
     }
     switch(addr) {
         case 0x0000 ... 0x1FFF: {
@@ -122,7 +123,7 @@ inline void RAM::set(u16 addr, u8 val) {
         case 0x2000 ... 0x3FFF: {
             this->rom_bank_low = val;
             this->rom_bank = (this->rom_bank_high << 5) | this->rom_bank_low;
-            if(this->debug) printf("rom_bank set to %u/%u\n", this->rom_bank, this->cart->rom_size / ROM_BANK_SIZE);
+            if(this->debug) fmt::print("rom_bank set to {}/{}\n", this->rom_bank, this->cart->rom_size / ROM_BANK_SIZE);
             if(this->rom_bank * ROM_BANK_SIZE > this->cart->rom_size) {
                 throw std::invalid_argument("Set rom_bank beyond the size of ROM");
             }
@@ -131,14 +132,16 @@ inline void RAM::set(u16 addr, u8 val) {
         case 0x4000 ... 0x5FFF: {
             if(this->ram_bank_mode) {
                 this->ram_bank = val;
-                if(this->debug) printf("ram_bank set to %u/%u\n", this->ram_bank, this->cart->ram_size / RAM_BANK_SIZE);
+                if(this->debug)
+                    fmt::print("ram_bank set to {}/{}\n", this->ram_bank, this->cart->ram_size / RAM_BANK_SIZE);
                 if(this->ram_bank * RAM_BANK_SIZE > this->cart->ram_size) {
                     throw std::invalid_argument("Set ram_bank beyond the size of RAM");
                 }
             } else {
                 this->rom_bank_high = val;
                 this->rom_bank = (this->rom_bank_high << 5) | this->rom_bank_low;
-                if(this->debug) printf("rom_bank set to %u/%u\n", this->rom_bank, this->cart->rom_size / ROM_BANK_SIZE);
+                if(this->debug)
+                    fmt::print("rom_bank set to {}/{}\n", this->rom_bank, this->cart->rom_size / ROM_BANK_SIZE);
                 if(this->rom_bank * ROM_BANK_SIZE > this->cart->rom_size) {
                     throw std::invalid_argument("Set rom_bank beyond the size of ROM");
                 }
@@ -163,7 +166,9 @@ inline void RAM::set(u16 addr, u8 val) {
             int bank = this->ram_bank * RAM_BANK_SIZE;
             int offset = addr - 0xA000;
             if(this->debug)
-                printf("Writing external RAM: %04X=%02X (%02X:%04X)\n", bank + offset, val, this->ram_bank, offset);
+                fmt::print(
+                    "Writing external RAM: {:#06X}={:#X} ({:#X}:{:#06X})\n", bank + offset, val, this->ram_bank,
+                    offset);
             if(bank + offset >= this->cart->ram_size) {
                 throw new InvalidRamWrite(this->ram_bank, offset, this->cart->ram_size);
             }


### PR DESCRIPTION
Instead of using plain C functions, we can use the {fmt} library. Currently, there's no implementation of
`std::format()`, so we have to use {fmt} instead. It's a more C++-ish thing to do.