### PR TITLE
[nim] disable panics for danger

### DIFF
--- a/nim/build_speed.sh
+++ b/nim/build_speed.sh
@@ -1,0 +1,5 @@
+set -eu
+
+cd $(dirname $0)
+nimble --accept build -d:danger --opt:speed -d:lto
+mv ./rosettaboy ./rosettaboy-speed


### PR DESCRIPTION
It is a bit strange, but in my tests with lto the panics::on slows down the speed/danger build:

`panics:on`: 2054fps
`else`: 2140fps