### PR TITLE
[zig] 0.11 is stable

### DIFF
--- a/.github/workflows/zig.yml
+++ b/.github/workflows/zig.yml
@@ -21,5 +21,5 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       workdir: zig
-      with-zig: 0.11.0-dev.3704+729a051e9
+      with-zig: 0.11.0
       build-pkgs: libsdl2-dev


### PR DESCRIPTION
[zig] 0.11 is stable

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/shish/rosettaboy/pull/139).
* #140
* __->__ #139