### PR TITLE
[py] cross platform sed

### DIFF
--- a/py/build_mypyc.sh
+++ b/py/build_mypyc.sh
@@ -4,7 +4,8 @@ cd $(dirname $0)
 source py_env.sh
 rm -rf rbmp
 cp -r src rbmp
-sed -i '' 's/from src./from rbmp./' rbmp/*.py
+sed -i.bak 's/from src./from rbmp./' rbmp/*.py
+rm -f rbmp/*.bak
 mypyc rbmp
 
 cat >rosettaboy-mypyc <<EOD


### PR DESCRIPTION
OSX sed and GNU sed have mutually-exclusive ways to say "rewrite in-place without backup", but there is a compatible way to say "rewrite in place and make a backup" so let's do that and then delete the backup...
